### PR TITLE
Use upload sessions for synthetic content uploads

### DIFF
--- a/scripts/08_Load-SyntheticContent.ps1
+++ b/scripts/08_Load-SyntheticContent.ps1
@@ -33,7 +33,10 @@ function Upload-FolderToDrive {
   if (-not $drive) { return }
   Get-ChildItem -Path $FolderPath -File | ForEach-Object {
     Write-Host "Uploading $($_.Name) -> $Alias"
-    New-MgDriveItemUpload -DriveId $drive.Id -Name $_.Name -FilePath $_.FullName -ConflictBehavior replace | Out-Null
+    $session = New-MgDriveItemUploadSession -DriveId $drive.Id -FileName $_.Name -AdditionalProperties @{
+      "@microsoft.graph.conflictBehavior" = "replace"
+    }
+    Invoke-MgUploadFile -InputFile $_.FullName -UploadUrl $session.UploadUrl | Out-Null
   }
 }
 


### PR DESCRIPTION
## Summary
- upload synthetic content using New-MgDriveItemUploadSession and Invoke-MgUploadFile

## Testing
- `pwsh -NoLogo -File scripts/08_Load-SyntheticContent.ps1 -ContentRoot .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a78ceffe0083248a159eddefb68850