### PR TITLE
Switch label cmdlets to compliance tag equivalents

### DIFF
--- a/scripts/05a_Create-Records-Labels.ps1
+++ b/scripts/05a_Create-Records-Labels.ps1
@@ -1,19 +1,19 @@
 param([string]$FilePlan = ".\config\fileplan.json")
 $plan = Get-Content $FilePlan -Raw | ConvertFrom-Json
 foreach ($item in $plan) {
-  $existing = Get-Label -Identity $item.Name -ErrorAction SilentlyContinue
+  $existing = Get-ComplianceTag -Identity $item.Name -ErrorAction SilentlyContinue
   if ($existing) { continue }
   $contentType = if ($item.ContentType) { $item.ContentType } else { "All" }
   if ($item.RetentionDurationDays) { $duration = "$($item.RetentionDurationDays) Days" }
   elseif ($item.RetentionDurationYears -lt 0) { $duration = "Unlimited" }
   else { $duration = "$($item.RetentionDurationYears) Years" }
   $trigger = if ($item.RetentionTrigger -eq "EventDate") { "Event" } else { "WhenCreated" }
-  New-Label -Name $item.Name `
+  New-ComplianceTag -Name $item.Name `
     -RetentionAction $item.Action `
     -RetentionDuration $duration `
     -RetentionType "KeepAndDelete" `
     -ContentType $contentType `
     -AdvancedSettings @{ "retentionTrigger" = $trigger; "eventType" = $item.EventType }
 }
-try { Set-Label -Identity "FOIA Requests – 6 Years" -IsRecordLabel $true } catch {}
-try { Set-Label -Identity "Contracts – 6 Years" -IsRecordLabel $true -AutoDelete $true } catch {}
+try { Set-ComplianceTag -Identity "FOIA Requests – 6 Years" -IsRecordLabel $true } catch {}
+try { Set-ComplianceTag -Identity "Contracts – 6 Years" -IsRecordLabel $true -AutoDelete $true } catch {}

--- a/scripts/05b_Create-Capstone-Email.ps1
+++ b/scripts/05b_Create-Capstone-Email.ps1
@@ -5,11 +5,11 @@ $permLabel = $cfg.Capstone.PermanentLabel
 $tempLabel = $cfg.Capstone.TemporaryLabel
 $tempYears = [int]$cfg.Capstone.TemporaryYears
 $capstoneUPNs = @(); $cfg.Capstone.MailboxRoles | ForEach-Object { $capstoneUPNs += $_.UPNs }
-if (-not (Get-Label -Identity $permLabel -ErrorAction SilentlyContinue)) {
-  New-Label -Name $permLabel -RetentionAction Keep -RetentionDuration Unlimited -ContentType "ExchangeEmail" -IsRecordLabel $true | Out-Null
+if (-not (Get-ComplianceTag -Identity $permLabel -ErrorAction SilentlyContinue)) {
+  New-ComplianceTag -Name $permLabel -RetentionAction Keep -RetentionDuration Unlimited -ContentType "ExchangeEmail" -IsRecordLabel $true | Out-Null
 }
-if (-not (Get-Label -Identity $tempLabel -ErrorAction SilentlyContinue)) {
-  New-Label -Name $tempLabel -RetentionAction KeepAndDelete -RetentionDuration "$tempYears Years" -ContentType "ExchangeEmail" -IsRecordLabel $false | Out-Null
+if (-not (Get-ComplianceTag -Identity $tempLabel -ErrorAction SilentlyContinue)) {
+  New-ComplianceTag -Name $tempLabel -RetentionAction KeepAndDelete -RetentionDuration "$tempYears Years" -ContentType "ExchangeEmail" -IsRecordLabel $false | Out-Null
 }
 $permPolicyName = "Capstone – Email Permanent"
 $tempPolicyName = "Agency Email – 7 Years"

--- a/scripts/utils/Wait-For-LabelReplication.ps1
+++ b/scripts/utils/Wait-For-LabelReplication.ps1
@@ -3,7 +3,7 @@ $start = Get-Date
 do {
   Start-Sleep -Seconds 30
   try {
-    $label = Get-Label -Identity $LabelName -ErrorAction Stop
+    $label = Get-ComplianceTag -Identity $LabelName -ErrorAction Stop
     if ($label) { return $true }
   } catch { }
 } while ((Get-Date) -lt $start.AddMinutes($TimeoutMinutes))


### PR DESCRIPTION
## Summary
- replace Get/New/Set-Label calls with Get/New/Set-ComplianceTag in retention scripts
- adjust label replication utility to use Get-ComplianceTag

## Testing
- `pwsh -NoLogo -Command "Get-Command Get-ComplianceTag"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a78d6cb82c8324bdae90fd55602c1c