### PR TITLE
refactor: drop graph beta profile

### DIFF
--- a/scripts/utils/Connect-Graph.ps1
+++ b/scripts/utils/Connect-Graph.ps1
@@ -4,5 +4,5 @@ param(
   [Parameter(Mandatory)] [string] $CertThumbprint
 )
 Import-Module Microsoft.Graph -ErrorAction Stop
+# Import Microsoft.Graph.Beta.* modules as needed for beta cmdlets.
 Connect-MgGraph -TenantId $TenantId -ClientId $AppId -CertificateThumbprint $CertThumbprint -NoWelcome
-Select-MgProfile -Name beta


### PR DESCRIPTION
## Summary
- remove deprecated Select-MgProfile call from Connect-Graph
- note to import Microsoft.Graph.Beta modules when beta endpoints are needed

## Testing
- `pwsh -NoProfile -File scripts/utils/Connect-Graph.ps1 -TenantId 'dummy' -AppId 'dummy' -CertThumbprint 'dummy'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a78fd34584832493164ba9dba327b2