### PR TITLE
Prompt for user account in authentication scripts

### DIFF
--- a/scripts/utils/Connect-Compliance.ps1
+++ b/scripts/utils/Connect-Compliance.ps1
@@ -3,8 +3,10 @@ param(
   [string] $Environment = 'Global'
 )
 Import-Module ExchangeOnlineManagement -ErrorAction Stop
+# Prompt for a user account to open an interactive authentication window.
+$account = Read-Host 'Enter the UPN for authentication'
 if ($Environment -eq 'USGov') {
-  Connect-IPPSSession -ConnectionUri 'https://ps.compliance.protection.office365.us/powershell-liveid/' -AzureADAuthorizationEndpointUri 'https://login.microsoftonline.us/common' | Out-Null
+  Connect-IPPSSession -UserPrincipalName $account -ConnectionUri 'https://ps.compliance.protection.office365.us/powershell-liveid/' -AzureADAuthorizationEndpointUri 'https://login.microsoftonline.us/common' | Out-Null
 } else {
-  Connect-IPPSSession | Out-Null
+  Connect-IPPSSession -UserPrincipalName $account | Out-Null
 }

--- a/scripts/utils/Connect-Graph.ps1
+++ b/scripts/utils/Connect-Graph.ps1
@@ -4,5 +4,7 @@ param(
 )
 Import-Module Microsoft.Graph -ErrorAction Stop
 # Import Microsoft.Graph.Beta.* modules as needed for beta cmdlets.
-Connect-MgGraph -Environment $Environment -NoWelcome
+# Prompt for a user account to open an interactive authentication window.
+$account = Read-Host 'Enter the UPN for authentication'
+Connect-MgGraph -Environment $Environment -NoWelcome -LoginHint $account
 Get-MgContext


### PR DESCRIPTION
## Summary
- prompt for user UPN in Graph connection without clearing existing context
- prompt for user UPN in compliance connection without removing sessions

## Testing
- `pwsh -NoLogo -Command "Write-Host 'Running PowerShell script checks'"` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden fetching Ubuntu packages)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a0388d1083248e30db3941e6f612