### PR TITLE
Refactor file plan schema to match compliance tag parameters

### DIFF
--- a/config/fileplan.json
+++ b/config/fileplan.json
@@ -1,50 +1,47 @@
 [
   {
-    "Name": "FOIA Disclosure Logs \u2013 Permanent",
-    "GRS": "GRS 4.2 Item 020",
-    "RetentionDurationYears": -1,
-    "RetentionTrigger": "CreationAgeInDays",
-    "Action": "Keep",
-    "RequiresDispositionReview": false,
+    "Name": "FOIA Disclosure Logs - Permanent",
+    "FilePlanProperty": "GRS 4.2 Item 020",
+    "RetentionAction": "Keep",
+    "RetentionDuration": "Unlimited",
+    "RetentionType": "AgeInDays",
     "ContentType": "All"
   },
   {
-    "Name": "FOIA Requests \u2013 6 Years",
-    "GRS": "GRS 4.2 Item 010",
-    "RetentionDurationYears": 6,
-    "RetentionTrigger": "EventDate",
+    "Name": "FOIA Requests - 6 Years",
+    "FilePlanProperty": "GRS 4.2 Item 010",
+    "RetentionAction": "KeepAndDelete",
+    "RetentionDuration": 2190,
+    "RetentionType": "EventBased",
     "EventType": "FOIACaseClosed",
-    "Action": "KeepAndDelete",
-    "RequiresDispositionReview": true,
-    "ContentType": "All"
+    "ContentType": "All",
+    "IsRecordLabel": true
   },
   {
-    "Name": "Contracts \u2013 6 Years",
-    "GRS": "GRS 1.1 Item 010",
-    "RetentionDurationYears": 6,
-    "RetentionTrigger": "EventDate",
+    "Name": "Contracts - 6 Years",
+    "FilePlanProperty": "GRS 1.1 Item 010",
+    "RetentionAction": "KeepAndDelete",
+    "RetentionDuration": 2190,
+    "RetentionType": "EventBased",
     "EventType": "ContractClose",
-    "Action": "KeepAndDelete",
-    "RequiresDispositionReview": true,
+    "ContentType": "All",
+    "IsRecordLabel": true,
+    "AutoDelete": true
+  },
+  {
+    "Name": "Program Planning - 3 Years",
+    "FilePlanProperty": "GRS 1.3 Item 010",
+    "RetentionAction": "KeepAndDelete",
+    "RetentionDuration": 1095,
+    "RetentionType": "AgeInDays",
     "ContentType": "All"
   },
   {
-    "Name": "Program Planning \u2013 3 Years",
-    "GRS": "GRS 1.3 Item 010",
-    "RetentionDurationYears": 3,
-    "RetentionTrigger": "CreationAgeInDays",
-    "Action": "KeepAndDelete",
-    "RequiresDispositionReview": true,
-    "ContentType": "All"
-  },
-  {
-    "Name": "Transitory Records \u2013 90 Days",
-    "GRS": "GRS 5.2 Item 010",
-    "RetentionDurationYears": 0,
-    "RetentionTrigger": "CreationAgeInDays",
-    "RetentionDurationDays": 90,
-    "Action": "Delete",
-    "RequiresDispositionReview": false,
+    "Name": "Transitory Records - 90 Days",
+    "FilePlanProperty": "GRS 5.2 Item 010",
+    "RetentionAction": "Delete",
+    "RetentionDuration": 90,
+    "RetentionType": "AgeInDays",
     "ContentType": "All"
   }
 ]

--- a/scripts/05a_Create-Records-Labels.ps1
+++ b/scripts/05a_Create-Records-Labels.ps1
@@ -3,17 +3,20 @@ $plan = Get-Content $FilePlan -Raw | ConvertFrom-Json
 foreach ($item in $plan) {
   $existing = Get-ComplianceTag -Identity $item.Name -ErrorAction SilentlyContinue
   if ($existing) { continue }
-  $contentType = if ($item.ContentType) { $item.ContentType } else { "All" }
-  if ($item.RetentionDurationDays) { $duration = "$($item.RetentionDurationDays) Days" }
-  elseif ($item.RetentionDurationYears -lt 0) { $duration = "Unlimited" }
-  else { $duration = "$($item.RetentionDurationYears) Years" }
-  $trigger = if ($item.RetentionTrigger -eq "EventDate") { "Event" } else { "WhenCreated" }
-  New-ComplianceTag -Name $item.Name `
-    -RetentionAction $item.Action `
-    -RetentionDuration $duration `
-    -RetentionType "KeepAndDelete" `
-    -ContentType $contentType `
-    -AdvancedSettings @{ "retentionTrigger" = $trigger; "eventType" = $item.EventType }
+  $params = @{
+    Name = $item.Name
+    RetentionAction = $item.RetentionAction
+    RetentionDuration = $item.RetentionDuration
+    RetentionType = $item.RetentionType
+    ContentType = $item.ContentType
+  }
+  if ($item.FilePlanProperty) { $params.FilePlanProperty = $item.FilePlanProperty }
+  if ($item.EventType) { $params.EventType = $item.EventType }
+  New-ComplianceTag @params
+  if ($item.IsRecordLabel -or $item.AutoDelete) {
+    $setParams = @{ Identity = $item.Name }
+    if ($item.IsRecordLabel) { $setParams.IsRecordLabel = $true }
+    if ($item.AutoDelete) { $setParams.AutoDelete = $true }
+    Set-ComplianceTag @setParams
+  }
 }
-try { Set-ComplianceTag -Identity "FOIA Requests – 6 Years" -IsRecordLabel $true } catch {}
-try { Set-ComplianceTag -Identity "Contracts – 6 Years" -IsRecordLabel $true -AutoDelete $true } catch {}


### PR DESCRIPTION
## Summary
- Align `fileplan.json` fields with `New-ComplianceTag` cmdlet parameters
- Simplify `05a_Create-Records-Labels.ps1` to map file plan values directly to cmdlet params
- Support optional record label and auto delete settings in the file plan
- Replace escaped en dashes with plain hyphens in file plan label names

## Testing
- `jq '.' config/fileplan.json >/dev/null`
- `pwsh -NoLogo -NoProfile -Command "Get-Content config/fileplan.json | ConvertFrom-Json | Out-Null"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7af830d4c83249eba2dee6cac0e1f