### PR TITLE
Fix record label creation and file plan JSON

### DIFF
--- a/config/fileplan.json
+++ b/config/fileplan.json
@@ -4,8 +4,7 @@
     "FilePlanProperty": "GRS 4.2 Item 020",
     "RetentionAction": "Keep",
     "RetentionDuration": "Unlimited",
-    "RetentionType": "AgeInDays",
-    
+    "RetentionType": "AgeInDays"
   },
   {
     "Name": "FOIA Requests - 6 Years",
@@ -23,8 +22,8 @@
     "RetentionDuration": 2190,
     "RetentionType": "EventAgeInDays",
     "EventType": "ContractClose",
-    "IsRecordLabel": "true",
-    "AutoDelete": "true"
+    "IsRecordLabel": true,
+    "AutoDelete": true
   },
   {
     "Name": "Program Planning - 3 Years",
@@ -38,6 +37,7 @@
     "FilePlanProperty": "GRS 5.2 Item 010",
     "RetentionAction": "Delete",
     "RetentionDuration": 90,
-    "RetentionType": "AgeInDays",
-    }
+    "RetentionType": "AgeInDays"
+  }
 ]
+

--- a/scripts/05a_Create-Records-Labels.ps1
+++ b/scripts/05a_Create-Records-Labels.ps1
@@ -1,6 +1,5 @@
 param([string]$FilePlan = ".\config\fileplan.json")
 $plan = Get-Content $FilePlan -Raw | ConvertFrom-Json
-$plan = $plan[1]
 foreach ($item in $plan) {
   if ($item.EventType) {
     $evt = Get-ComplianceRetentionEventType -Identity $item.EventType -ErrorAction SilentlyContinue
@@ -11,13 +10,20 @@ foreach ($item in $plan) {
   $existing = Get-ComplianceTag -Identity $item.Name -ErrorAction SilentlyContinue
   if ($existing) { continue }
   $params = @{
-    Name = $item.Name
-    RetentionAction = $item.RetentionAction
+    Name             = $item.Name
+    RetentionAction  = $item.RetentionAction
     RetentionDuration = $item.RetentionDuration
-    RetentionType = $item.RetentionType
-      }
-  if ($item.FilePlanProperty) { $params.FilePlanProperty = $item.FilePlanProperty }
-  if ($item.IsRecordLabel) { $params.IsRecordLabel = $item.IsRecordLabel }
+    RetentionType    = $item.RetentionType
+  }
+  if ($item.FilePlanProperty) {
+    $params.FilePlanProperty = @{ ReferenceId = $item.FilePlanProperty }
+  }
+  if ($null -ne $item.IsRecordLabel) {
+    $params.IsRecordLabel = [bool]$item.IsRecordLabel
+  }
+  if ($null -ne $item.AutoDelete) {
+    $params.AutoDelete = [bool]$item.AutoDelete
+  }
   if ($item.EventType) { $params.EventType = $item.EventType }
   New-ComplianceTag @params
 }


### PR DESCRIPTION
## Summary
- Fix script to cast IsRecordLabel/AutoDelete booleans and supply FilePlanProperty as ReferenceId
- Read entire file plan and support AutoDelete
- Clean up fileplan.json with proper booleans and valid JSON format

## Testing
- `python -m json.tool config/fileplan.json`
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c550276c832497b325fda2d63645