### PR TITLE
Add logging and optional license group creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A one-click demo for Microsoft Purview Records Management aligned to **NARA GRS*
    ```powershell
    # Add -Cloud USGov when connecting to a GCC tenant
    pwsh -File .\scripts\00_Prepare-Env.ps1
-   pwsh -File .\scripts\01_Seed-Users-And-Mail.ps1
+   pwsh -File .\scripts\01_Seed-Users-And-Mail.ps1 -CreateLicenseGroup
    pwsh -File .\scripts\02_Provision-SharePointSites.ps1
    pwsh -File .\scripts\03_Provision-Teams.ps1
    pwsh -File .\scripts\05a_Create-Records-Labels.ps1
@@ -23,7 +23,7 @@ A one-click demo for Microsoft Purview Records Management aligned to **NARA GRS*
    Expand-Archive -Path .\synthetic-data\synthetic-content-federal-full.zip -DestinationPath .\synthetic-content -Force
    pwsh -File .\scripts\08_Load-SyntheticContent.ps1 -ContentRoot .\synthetic-content -TeamName "Records Demo Team" -FromUpn "record.manager@contoso.com"
    ```
-   Scripts authenticate interactively using the signed-in user.
+Scripts authenticate interactively using the signed-in user. Log output is written to `logs/01_Seed-Users-And-Mail.log`.
 
 ## One‑click via GitHub Actions
 - **Provision Purview Demo (Federal)**: provisions labels/policies + unzips and loads synthetic content.


### PR DESCRIPTION
## Summary
- add structured logging with environment details to user seeding script
- make E5 license group creation optional and verify license availability
- document new usage and log file location

## Testing
- `pwsh -NoLogo -NoProfile -File scripts/01_Seed-Users-And-Mail.ps1 -CreateLicenseGroup` *(fails: pwsh not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a81a4ecae083249579eac09eef4098