### PR TITLE
Split user and mail seeding scripts and document required demo rights

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ A one-click demo for Microsoft Purview Records Management aligned to **NARA GRS*
    ```powershell
    # Add -Cloud USGov when connecting to a GCC tenant
    pwsh -File .\scripts\00_Prepare-Env.ps1
-   pwsh -File .\scripts\01_Seed-Users-And-Mail.ps1 -CreateLicenseGroup
+   pwsh -File .\scripts\01_Seed-Users.ps1 -CreateLicenseGroup
+   # wait for Entra ID replication before sending seed mail
+   pwsh -File .\scripts\01b_Seed-Mail.ps1
    pwsh -File .\scripts\02_Provision-SharePointSites.ps1
    pwsh -File .\scripts\03_Provision-Teams.ps1
    pwsh -File .\scripts\05a_Create-Records-Labels.ps1
@@ -23,7 +25,7 @@ A one-click demo for Microsoft Purview Records Management aligned to **NARA GRS*
    Expand-Archive -Path .\synthetic-data\synthetic-content-federal-full.zip -DestinationPath .\synthetic-content -Force
    pwsh -File .\scripts\08_Load-SyntheticContent.ps1 -ContentRoot .\synthetic-content -TeamName "Records Demo Team" -FromUpn "record.manager@contoso.com"
    ```
-Scripts authenticate interactively using the signed-in user. Log output is written to `logs/01_Seed-Users-And-Mail.log`.
+Scripts authenticate interactively using the signed-in user. Log output is written to `logs/01_Seed-Users.log` and `logs/01b_Seed-Mail.log`.
 
 ## One‑click via GitHub Actions
 - **Provision Purview Demo (Federal)**: provisions labels/policies + unzips and loads synthetic content.

--- a/docs/demo-rights.md
+++ b/docs/demo-rights.md
@@ -1,0 +1,19 @@
+# Demo Rights
+
+The table below lists the recommended permissions for each step of the demo.
+
+| Step | Script | Required Rights | Notes |
+| ---- | ------ | --------------- | ----- |
+| 0 | `00_Prepare-Env.ps1` | Global Administrator; Compliance Administrator | Establishes connections to Graph and Purview. |
+| 1 | `01_Seed-Users.ps1` | Global Administrator | Creates demo users and assigns E5 licenses. |
+| 1b | `01b_Seed-Mail.ps1` | Mail.Send delegated permission; run after directory replication | Sends the initial seed email between demo accounts. |
+| 2 | `02_Provision-SharePointSites.ps1` | SharePoint Administrator | Creates required SharePoint sites. |
+| 3 | `03_Provision-Teams.ps1` | Teams Administrator | Creates the Teams workspace and channels, adds demo users as owners. |
+| 5a | `05a_Create-Records-Labels.ps1` | Records Management or Compliance Administrator role | Creates retention labels and publishes them to SharePoint sites. |
+| 5b | `05b_Create-Capstone-Email.ps1` | Exchange Administrator; Records Management or Compliance Administrator | Configures capstone email retention policies. |
+| 6a | `06a_Create-AutoApply-Policies.ps1` | Records Management or Compliance Administrator | Creates keyword-based auto-apply policies. |
+| 6b | `06b_Scope-WorkloadCoverage.ps1` | Records Management read access | Displays the workloads included in each retention policy. |
+| 7 | `07_Demo-Flows.ps1` | Records Management or Compliance Administrator | Registers retention events for the demo storyline. |
+| 8 | `08_Load-SyntheticContent.ps1` | SharePoint and Teams membership; Mail.Send permission for `FromUpn` | Uploads synthetic files and posts sample Teams chats. |
+
+Demo users such as `record.manager@contoso.com`, `contract.officer@contoso.com`, and `foia.officer@contoso.com` should be assigned the roles above as needed to execute their respective parts of the demo.

--- a/scripts/01_Seed-Users.ps1
+++ b/scripts/01_Seed-Users.ps1
@@ -2,7 +2,7 @@ param(
     [string]$UsersCsv = ".\config\users.csv",
     [string]$LicenseGroupName = "E5 License Group",
     [switch]$CreateLicenseGroup,
-    [string]$LogFile = ".\logs\01_Seed-Users-And-Mail.log"
+    [string]$LogFile = ".\logs\01_Seed-Users.log"
 )
 
 $logDir = Split-Path $LogFile
@@ -118,25 +118,3 @@ foreach ($u in $users) {
         }
     }
 }
-
-# Seed mail
-$from = "record.manager@contoso.com"
-$to = "contract.officer@contoso.com"
-$msg = @{
-  subject = "RFP ACQ-24-019 Statement of Work and Closeout"
-  body = @{ contentType = "Text"; content = "Please review the attached RFP and prepare award memo. Closeout date is 2025-09-30." }
-  toRecipients = @(@{emailAddress=@{address=$to}})
-}
-try {
-  $fromUser = Get-MgUser -Filter "userPrincipalName eq '$from'" -ErrorAction SilentlyContinue
-  $toUser = Get-MgUser -Filter "userPrincipalName eq '$to'" -ErrorAction SilentlyContinue
-  if ($fromUser -and $toUser) {
-    Send-MgUserMail -UserId $from -Message $msg -SaveToSentItems
-    Write-Log -Level "INFO" -Action "Seed mail sent" -Details "$from -> $to"
-  } else {
-    Write-Log -Level "Warning" -Action "Skipping seed mail" -Details "Required accounts missing"
-  }
-} catch {
-  Write-Log -Level "Warning" -Action "Failed sending seed mail" -Details $_
-}
-

--- a/scripts/01b_Seed-Mail.ps1
+++ b/scripts/01b_Seed-Mail.ps1
@@ -1,0 +1,61 @@
+param(
+    [string]$From = "record.manager@contoso.com",
+    [string]$To   = "contract.officer@contoso.com",
+    [string]$LogFile = ".\logs\01b_Seed-Mail.log"
+)
+
+$logDir = Split-Path $LogFile
+if (-not (Test-Path $logDir)) { New-Item -ItemType Directory -Path $logDir -Force | Out-Null }
+
+function Write-Log {
+    param([string]$Level, [string]$Action, [string]$Details = "")
+    $entry = [PSCustomObject]@{
+        Timestamp = (Get-Date).ToString("o")
+        Level     = $Level
+        Action    = $Action
+        Details   = $Details
+    }
+    $entry | ConvertTo-Json -Compress | Add-Content -Path $LogFile
+    if ($Level -eq "Warning") {
+        Write-Warning "$Action $Details"
+    } else {
+        Write-Host "$Action $Details"
+    }
+}
+
+$runInfo = [PSCustomObject]@{
+    Timestamp = (Get-Date).ToString("o")
+    AdminUser = [Environment]::UserName
+    Machine   = [Environment]::MachineName
+    OS        = [System.Environment]::OSVersion.VersionString
+    Script    = $MyInvocation.MyCommand.Path
+}
+$runInfo | ConvertTo-Json -Compress | Set-Content -Path $LogFile
+
+foreach ($m in @("Microsoft.Graph.Users","Microsoft.Graph.Mail")) {
+    try {
+        Install-Module $m -Force
+        Import-Module $m
+        Write-Log -Level "INFO" -Action "Module loaded" -Details $m
+    } catch {
+        Write-Log -Level "Warning" -Action "Module load failed" -Details "$m : $_"
+    }
+}
+
+$msg = @{
+  subject = "RFP ACQ-24-019 Statement of Work and Closeout"
+  body = @{ contentType = "Text"; content = "Please review the attached RFP and prepare award memo. Closeout date is 2025-09-30." }
+  toRecipients = @(@{emailAddress=@{address=$To}})
+}
+try {
+  $fromUser = Get-MgUser -Filter "userPrincipalName eq '$From'" -ErrorAction SilentlyContinue
+  $toUser = Get-MgUser -Filter "userPrincipalName eq '$To'" -ErrorAction SilentlyContinue
+  if ($fromUser -and $toUser) {
+    Send-MgUserMail -UserId $From -Message $msg -SaveToSentItems
+    Write-Log -Level "INFO" -Action "Seed mail sent" -Details "$From -> $To"
+  } else {
+    Write-Log -Level "Warning" -Action "Skipping seed mail" -Details "Required accounts missing"
+  }
+} catch {
+  Write-Log -Level "Warning" -Action "Failed sending seed mail" -Details $_
+}


### PR DESCRIPTION
## Summary
- split user creation into `01_Seed-Users.ps1` and move email seeding to `01b_Seed-Mail.ps1`
- document required permissions for each demo step in `docs/demo-rights.md`
- update README to reference new scripts and logs

## Testing
- `pwsh -NoLogo -NoProfile -Command "Install-Module PSScriptAnalyzer -Scope CurrentUser -Force; Invoke-ScriptAnalyzer -Path scripts/01_Seed-Users.ps1, scripts/01b_Seed-Mail.ps1"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a879cb8c2483248f178cc63abad982